### PR TITLE
Функционал копирования выделеного текста

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,7 @@
 <body>
 
   <ul class="menu" id="menu"></ul>
+  <p>Какой-то текст</p>
 
 </body>
 

--- a/src/modules/textCopy.js
+++ b/src/modules/textCopy.js
@@ -7,34 +7,27 @@ export class Copy extends Module
     constructor(type = 'copy_text', text = 'Копировать') {
         super(type, text);
 
-        //Событие клика для проверки, что мы вышли из контекстного меню
-        document.addEventListener('click', () => {
-            this.#contextMenu = false;
-        })
-
-        //Событие открытия конекстного для проверкичто бы в него вошли
-        document.addEventListener('contextmenu', () => {
-            this.#contextMenu = true;
-        });
-
-        //Событие смены текущего выделения
-        document.addEventListener('selectionchange', event => {
-            if(!this.#contextMenu)
+        document.body.addEventListener('mouseup', event => {
+            const element = document.querySelector('.menu.open');
+            if(!element)
             {
                 this.#selection();
             }
-        });
+        })
     }
 
     trigger()
     {
-        //API clipboard для асинхронного взаимодействия с буфером обмена
-        navigator.clipboard.writeText(this.#selectText)
-            .then()
-            .catch((error) =>{
-                console.error(error);
-            }
-        );
+        if(this.#selectText.length > 0)
+        {
+            //API clipboard для асинхронного взаимодействия с буфером обмена
+            navigator.clipboard.writeText(this.#selectText)
+                .then()
+                .catch((error) =>{
+                        console.error(error);
+                }
+            );
+        }
     }
 
     //Записываем выделенный текс в переменную

--- a/src/modules/textCopy.js
+++ b/src/modules/textCopy.js
@@ -1,0 +1,45 @@
+import {Module} from "@/core/module";
+
+export class Copy extends Module
+{
+    #selectText;
+    #contextMenu;
+    constructor(type = 'copy_text', text = 'Копировать') {
+        super(type, text);
+
+        //Событие клика для проверки, что мы вышли из контекстного меню
+        document.addEventListener('click', () => {
+            this.#contextMenu = false;
+        })
+
+        //Событие открытия конекстного для проверкичто бы в него вошли
+        document.addEventListener('contextmenu', () => {
+            this.#contextMenu = true;
+        });
+
+        //Событие смены текущего выделения
+        document.addEventListener('selectionchange', event => {
+            if(!this.#contextMenu)
+            {
+                this.#selection();
+            }
+        });
+    }
+
+    trigger()
+    {
+        //API clipboard для асинхронного взаимодействия с буфером обмена
+        navigator.clipboard.writeText(this.#selectText)
+            .then()
+            .catch((error) =>{
+                console.error(error);
+            }
+        );
+    }
+
+    //Записываем выделенный текс в переменную
+    #selection()
+    {
+        this.#selectText = window.getSelection().toString();
+    }
+}


### PR DESCRIPTION
Так как мы заменили Контекстное меню у нас пропал главный функционал любого программиста.
Я считаю, что его необходимо вернуть.
Данный модуль позволяет скопировать выделенный текст в буфер обмена.

Есть костыль для обхода выделения контекстного меню, может у кого будут предложения как от него избавиться.